### PR TITLE
Update star count

### DIFF
--- a/src/views/Home/components/Features/index.tsx
+++ b/src/views/Home/components/Features/index.tsx
@@ -30,7 +30,7 @@ const features: Feature[] = [
         icon: faCheck,
         title: 'Trusted by Many',
         excerpt:
-            'Trusted by many users with public source code available for viewing, garnering over 400 stars on GitHub.',
+            'Trusted by many users with public source code available for viewing, garnering over 600 stars on GitHub.',
     },
     {
         icon: faLock,


### PR DESCRIPTION
I'd like to see this become automatic in the future, always showing a number smaller than the current, at intervals of 50 (so if it has 700 stars it says "more than 650!").