### PR TITLE
Change the plugin source indicator to not look like a button

### DIFF
--- a/src/views/Plugins/Details.tsx
+++ b/src/views/Plugins/Details.tsx
@@ -55,7 +55,9 @@ interface PluginSourceChipProps {
 
 function PluginSourceChip(props: PluginSourceChipProps) {
     return (
-        <span class={`rounded-full px-2 py-0.5 font-semibold ${chipStyles[props.source]}`}>
+        <span
+            class={`rounded-full px-2 py-0.5 font-semibold ${chipStyles[props.source]}`}
+        >
             {props.source}
         </span>
     )
@@ -177,7 +179,11 @@ export default function PluginDetails() {
                                                 <h1 class="text-2xl font-bold">
                                                     {plugin().name}
                                                 </h1>
-                                                <PluginSourceChip source={getPluginSource(plugin().filePath)} />
+                                                <PluginSourceChip
+                                                    source={getPluginSource(
+                                                        plugin().filePath,
+                                                    )}
+                                                />
                                             </div>
                                             <div class="flex items-center gap-2 font-medium text-neutral-300">
                                                 <Users size={16} />


### PR DESCRIPTION
In its old style (see below) the indicator with the plugin source looked like and was next to a button. This moves it away from the button and also gives it some color.

# Old

<img width="1442" height="232" alt="image" src="https://github.com/user-attachments/assets/bcef8d28-303c-4b32-a15c-8d046947a911" />

# New

<img width="584" height="139" alt="image" src="https://github.com/user-attachments/assets/f02050bc-382b-4b48-a907-422e4e993a0f" />

<img width="584" height="112" alt="image" src="https://github.com/user-attachments/assets/432d650c-2785-41af-811c-5b6a2df418a5" />

<img width="574" height="100" alt="image" src="https://github.com/user-attachments/assets/474f40a8-1bbb-4f63-af18-9296a4bbf75c" />
