### PR TITLE
Better UI for tab buttons when a plugin has no commands

### DIFF
--- a/src/components/UI/Button.tsx
+++ b/src/components/UI/Button.tsx
@@ -20,16 +20,16 @@ export default function Button(props: Props) {
         <button
             {...rest}
             class={classNames(
-                'flex cursor-pointer items-center justify-center gap-1 rounded-xl border px-6 py-3 font-bold transition-all active:scale-[.95]',
+                'flex items-center justify-center gap-1 rounded-xl border px-6 py-3 font-bold transition-all disabled:opacity-50 disabled:cursor-not-allowed enabled:cursor-pointer  active:enabled:scale-[.95]',
                 local.class,
                 {
-                    'border-white bg-neutral-100 text-neutral-800 hover:bg-neutral-300 hover:text-neutral-900':
+                    'border-white bg-neutral-100 text-neutral-800 hover:enabled:bg-neutral-300 hover:enabled:text-neutral-900':
                         local.buttonColor === 'primary',
-                    'border-neutral-800/50 bg-neutral-900 text-neutral-300 hover:bg-neutral-800/70 hover:text-neutral-200':
+                    'border-neutral-800/50 bg-neutral-900 text-neutral-300 hover:enabled:bg-neutral-800/70 hover:enabled:text-neutral-200':
                         local.buttonColor === 'secondary',
-                    'border-sky-700/50 bg-sky-900 text-sky-200 hover:bg-sky-800':
+                    'border-sky-700/50 bg-sky-900 text-sky-200 hover:enabled:bg-sky-800':
                         local.buttonColor === 'blue',
-                    'border-red-300/50 bg-red-300 text-red-900 hover:bg-red-400 hover:text-red-950':
+                    'border-red-300/50 bg-red-300 text-red-900 hover:enabled:bg-red-400 hover:enabled:text-red-950':
                         local.buttonColor === 'red',
                 },
             )}

--- a/src/views/Plugins/Details.tsx
+++ b/src/views/Plugins/Details.tsx
@@ -200,23 +200,19 @@ export default function PluginDetails() {
                                     >
                                         Overview
                                     </Button>
-
-                                    <Show when={plugin().hasCommands}>
-                                        <Button
-                                            icon={<Braces size={16} />}
-                                            buttonColor={
-                                                activeTab() === 'commands'
-                                                    ? 'primary'
-                                                    : 'secondary'
-                                            }
-                                            class="text-sm"
-                                            onClick={() =>
-                                                setActiveTab('commands')
-                                            }
-                                        >
-                                            Commands
-                                        </Button>
-                                    </Show>
+                                    <Button
+                                        icon={<Braces size={16} />}
+                                        disabled={!plugin().hasCommands}
+                                        buttonColor={
+                                            activeTab() === 'commands'
+                                                ? 'primary'
+                                                : 'secondary'
+                                        }
+                                        class="text-sm"
+                                        onClick={() => plugin().hasCommands && setActiveTab('commands')}
+                                    >
+                                        Commands
+                                    </Button>
                                 </div>
 
                                 {/* Content */}


### PR DESCRIPTION
currently, if a plugin has no commands, the commands tab button is hidden, but the overview button is still visually responsive to user events and does nothing. This makes it very confusing what it does when you hover over it on a plugin that has no commands.